### PR TITLE
Update SimpleDataProvider.php

### DIFF
--- a/src/Model/Export/Catalog/ProductType/SimpleDataProvider.php
+++ b/src/Model/Export/Catalog/ProductType/SimpleDataProvider.php
@@ -55,7 +55,7 @@ class SimpleDataProvider implements DataProviderInterface, ExportEntityInterface
             'Name'          => (string) $this->product->getName(),
             'Description'   => (string) $this->product->getData('description'),
             'Short'         => (string) $this->product->getData('short_description'),
-            'ProductURL'    => (string) $this->product->getUrlInStore(),
+            'ProductURL'    => (string) $this->product->getProductUrl(),
             'Price'         => $this->numberFormatter->format((float) $this->product->getFinalPrice()),
             'Brand'         => (string) $this->product->getAttributeText('manufacturer'),
             'Availability'  => (int) $this->product->isAvailable(),


### PR DESCRIPTION
get product url without store param

- Solves issue: 
- Description: 
- Tested with Magento editions/versions: 
- Tested with PHP versions: 

**Please note that the source and target branch must be `develop` ([details](https://github.com/FACT-Finder-Web-Components/magento2-module/blob/HEAD/.github/CONTRIBUTING.md)).**
